### PR TITLE
Fix hour data

### DIFF
--- a/src/Data.js
+++ b/src/Data.js
@@ -41,7 +41,7 @@ export function withTopics(cards) {
     },
     {
       title: "ENCERRAMENTOS DAS PALESTRAS",
-      hour: "18:0",
+      hour: "18:00",
       type: "topic",
     },
     {


### PR DESCRIPTION
Consertando a hora do encerramentos das palestras que estava de forma errada.

Exemplo:
<img width="574" alt="image" src="https://github.com/jv-farias/frontend-day-app/assets/74427958/5b800abb-9a79-4a4c-8a19-459aac05ea1d">
